### PR TITLE
FreeT Methods: hoist, interpret, bimap methods.

### DIFF
--- a/src/main/java/org/highj/function/NF.java
+++ b/src/main/java/org/highj/function/NF.java
@@ -16,4 +16,13 @@ public interface NF<F,G> extends __2<NF.µ,F,G> {
     }
 
     <A> __<G,A> apply(__<F,A> a);
+
+    static <F_> NF<F_,F_> identity() {
+        return new NF<F_,F_>() {
+            @Override
+            public <A> __<F_, A> apply(__<F_, A> a) {
+                return a;
+            }
+        };
+    }
 }


### PR DESCRIPTION
Those methods are enough to derive a regular ```Free``` from a ```FreeT``` to avoid code doubling up.